### PR TITLE
feat: Add AI Showcase section and AWS AppConfig feature flags

### DIFF
--- a/backend/handlers/get_feature_flags.js
+++ b/backend/handlers/get_feature_flags.js
@@ -1,0 +1,128 @@
+const { AppConfigDataClient, StartConfigurationSessionCommand, GetLatestConfigurationCommand } = require("@aws-sdk/client-appconfigdata");
+
+const client = new AppConfigDataClient({ region: "us-east-1" });
+
+// Cache for configuration session token and flags
+let sessionToken = null;
+let cachedFlags = null;
+let lastFetch = 0;
+const CACHE_TTL_MS = 30000; // 30 seconds cache
+
+exports.handler = async (event) => {
+  console.log("get-feature-flags invoked", JSON.stringify(event));
+
+  // Get environment from query param or default to production
+  const environment = event.queryStringParameters?.environment || "production";
+
+  // Validate environment
+  if (!["staging", "production"].includes(environment)) {
+    return {
+      statusCode: 400,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+      body: JSON.stringify({ error: "Invalid environment. Must be 'staging' or 'production'." }),
+    };
+  }
+
+  try {
+    const now = Date.now();
+
+    // Check if we have cached flags that are still valid
+    if (cachedFlags && (now - lastFetch) < CACHE_TTL_MS) {
+      console.log("Returning cached flags");
+      return {
+        statusCode: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*",
+          "Cache-Control": "public, max-age=30",
+        },
+        body: JSON.stringify(cachedFlags),
+      };
+    }
+
+    // Start a new configuration session if we don't have a token
+    if (!sessionToken) {
+      const sessionCommand = new StartConfigurationSessionCommand({
+        ApplicationIdentifier: process.env.APPCONFIG_APP_ID,
+        EnvironmentIdentifier: environment,
+        ConfigurationProfileIdentifier: process.env.APPCONFIG_PROFILE_ID,
+      });
+
+      const sessionResponse = await client.send(sessionCommand);
+      sessionToken = sessionResponse.InitialConfigurationToken;
+      console.log("Started new configuration session");
+    }
+
+    // Get the latest configuration
+    const configCommand = new GetLatestConfigurationCommand({
+      ConfigurationToken: sessionToken,
+    });
+
+    const configResponse = await client.send(configCommand);
+
+    // Update session token for next call
+    sessionToken = configResponse.NextPollConfigurationToken;
+
+    // Parse the configuration if there's new content
+    if (configResponse.Configuration && configResponse.Configuration.length > 0) {
+      const configString = new TextDecoder().decode(configResponse.Configuration);
+      const config = JSON.parse(configString);
+
+      // Transform AppConfig feature flags format to simpler format
+      const flags = {};
+      if (config.values) {
+        for (const [key, value] of Object.entries(config.values)) {
+          flags[key] = value.enabled || false;
+        }
+      }
+
+      cachedFlags = {
+        environment,
+        flags,
+        fetchedAt: new Date().toISOString(),
+      };
+      lastFetch = now;
+
+      console.log("Fetched new configuration", cachedFlags);
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+        "Cache-Control": "public, max-age=30",
+      },
+      body: JSON.stringify(cachedFlags || { environment, flags: {}, fetchedAt: new Date().toISOString() }),
+    };
+  } catch (error) {
+    console.error("Error fetching feature flags:", error);
+
+    // Reset session token on error to force new session
+    sessionToken = null;
+
+    // Return default flags on error (fail open with safe defaults)
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      },
+      body: JSON.stringify({
+        environment,
+        flags: {
+          showAIShowcase: false,
+          showContributions: true,
+          showResumeDownload: false,
+          enableJobFitAnalyzer: true,
+          enableJobFitUrl: true,
+        },
+        fetchedAt: new Date().toISOString(),
+        fallback: true,
+      }),
+    };
+  }
+};

--- a/src/src/app/layout.tsx
+++ b/src/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { Navbar } from "@/components/Navbar";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { FeatureFlagsProvider } from "@/lib/featureFlags";
 
 import GoogleAnalytics from "@/components/GoogleAnalytics";
 
@@ -52,19 +53,21 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
         >
-          {/* Skip to main content link for accessibility */}
-          <a
-            href="#main-content"
-            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:outline-none"
-          >
-            Skip to main content
-          </a>
-          <Navbar />
-          <ErrorBoundary>
-            <main id="main-content" className="flex flex-col items-center">
-                {children}
-            </main>
-          </ErrorBoundary>
+          <FeatureFlagsProvider>
+            {/* Skip to main content link for accessibility */}
+            <a
+              href="#main-content"
+              className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:outline-none"
+            >
+              Skip to main content
+            </a>
+            <Navbar />
+            <ErrorBoundary>
+              <main id="main-content" className="flex flex-col items-center">
+                  {children}
+              </main>
+            </ErrorBoundary>
+          </FeatureFlagsProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/src/src/components/AIShowcase.tsx
+++ b/src/src/components/AIShowcase.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Brain, Sparkles, Rocket, ExternalLink, Github } from 'lucide-react';
+import { useFeatureFlag } from '@/lib/featureFlags';
 
 interface AIProject {
   title: string;
@@ -44,6 +45,13 @@ const statusConfig = {
 };
 
 export function AIShowcase({ projects = defaultProjects }: AIShowcaseProps) {
+  const showAIShowcase = useFeatureFlag('showAIShowcase');
+
+  // Feature flag controls visibility
+  if (!showAIShowcase) {
+    return null;
+  }
+
   return (
     <section className="w-full py-12 md:py-20 px-4 bg-gradient-to-b from-violet-50/50 to-background dark:from-violet-950/20 dark:to-background">
       <div className="max-w-6xl mx-auto">

--- a/src/src/lib/featureFlags.tsx
+++ b/src/src/lib/featureFlags.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useState, useEffect, createContext, useContext, ReactNode } from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+// Feature flag types
+export interface FeatureFlags {
+  showAIShowcase: boolean;
+  showContributions: boolean;
+  showResumeDownload: boolean;
+  enableJobFitAnalyzer: boolean;
+  enableJobFitUrl: boolean;
+}
+
+// Default flags (used when API unavailable or for SSR)
+export const defaultFlags: FeatureFlags = {
+  showAIShowcase: true,
+  showContributions: true,
+  showResumeDownload: false,
+  enableJobFitAnalyzer: true,
+  enableJobFitUrl: true,
+};
+
+interface FeatureFlagsResponse {
+  environment: string;
+  flags: Partial<FeatureFlags>;
+  fetchedAt: string;
+  fallback?: boolean;
+}
+
+interface FeatureFlagsContextValue {
+  flags: FeatureFlags;
+  isLoading: boolean;
+  error: string | null;
+  environment: string | null;
+}
+
+const FeatureFlagsContext = createContext<FeatureFlagsContextValue>({
+  flags: defaultFlags,
+  isLoading: true,
+  error: null,
+  environment: null,
+});
+
+// Determine environment based on hostname
+function getEnvironment(): string {
+  if (typeof window === "undefined") return "production";
+
+  const hostname = window.location.hostname;
+
+  // Staging detection - adjust these patterns based on your setup
+  if (
+    hostname.includes("staging") ||
+    hostname.includes("dev") ||
+    hostname === "localhost" ||
+    hostname === "127.0.0.1"
+  ) {
+    return "staging";
+  }
+
+  return "production";
+}
+
+// Fetch feature flags from API
+async function fetchFeatureFlags(environment: string): Promise<FeatureFlagsResponse> {
+  if (!API_URL) {
+    return {
+      environment,
+      flags: defaultFlags,
+      fetchedAt: new Date().toISOString(),
+      fallback: true,
+    };
+  }
+
+  try {
+    const res = await fetch(`${API_URL}/feature-flags?environment=${environment}`, {
+      cache: "no-store",
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to fetch feature flags: ${res.status}`);
+    }
+
+    return res.json();
+  } catch (error) {
+    console.warn("Failed to fetch feature flags, using defaults:", error);
+    return {
+      environment,
+      flags: defaultFlags,
+      fetchedAt: new Date().toISOString(),
+      fallback: true,
+    };
+  }
+}
+
+// Hook for consuming feature flags
+export function useFeatureFlags(): FeatureFlagsContextValue {
+  return useContext(FeatureFlagsContext);
+}
+
+// Hook for checking a specific feature flag
+export function useFeatureFlag(flagName: keyof FeatureFlags): boolean {
+  const { flags } = useFeatureFlags();
+  return flags[flagName] ?? defaultFlags[flagName];
+}
+
+// Provider component props
+interface FeatureFlagsProviderProps {
+  children: ReactNode;
+}
+
+// Provider component
+export function FeatureFlagsProvider({ children }: FeatureFlagsProviderProps) {
+  const [flags, setFlags] = useState<FeatureFlags>(defaultFlags);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [environment, setEnvironment] = useState<string | null>(null);
+
+  useEffect(() => {
+    const env = getEnvironment();
+    setEnvironment(env);
+
+    fetchFeatureFlags(env)
+      .then((response) => {
+        setFlags({
+          ...defaultFlags,
+          ...response.flags,
+        });
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        setError(err.message);
+        setIsLoading(false);
+      });
+  }, []);
+
+  return (
+    <FeatureFlagsContext.Provider value={{ flags, isLoading, error, environment }}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
+}
+
+// Standalone function for server-side or one-off fetches
+export async function getFeatureFlags(environment?: string): Promise<FeatureFlags> {
+  const env = environment || "production";
+  const response = await fetchFeatureFlags(env);
+  return {
+    ...defaultFlags,
+    ...response.flags,
+  };
+}

--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -58,7 +58,27 @@ resource "aws_lambda_permission" "api_enhance_content" {
   source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*"
 }
 
+# GET /feature-flags -> get_feature_flags lambda
 
+resource "aws_apigatewayv2_integration" "get_feature_flags" {
+  api_id           = aws_apigatewayv2_api.http_api.id
+  integration_type = "AWS_PROXY"
+  integration_uri  = aws_lambda_function.get_feature_flags.invoke_arn
+}
+
+resource "aws_apigatewayv2_route" "get_feature_flags" {
+  api_id    = aws_apigatewayv2_api.http_api.id
+  route_key = "GET /feature-flags"
+  target    = "integrations/${aws_apigatewayv2_integration.get_feature_flags.id}"
+}
+
+resource "aws_lambda_permission" "api_get_feature_flags" {
+  statement_id  = "AllowExecutionFromAPIGatewayFeatureFlags"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.get_feature_flags.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.http_api.execution_arn}/*/*"
+}
 
 output "api_endpoint" {
   value = aws_apigatewayv2_api.http_api.api_endpoint

--- a/terraform/appconfig.tf
+++ b/terraform/appconfig.tf
@@ -1,0 +1,225 @@
+# AWS AppConfig for Feature Flags
+# Enables runtime feature toggling without redeployment
+
+# AppConfig Application
+resource "aws_appconfig_application" "portfolio" {
+  name        = "portfolio-app"
+  description = "Feature flags for Jeremy Spofford Portfolio"
+
+  tags = {
+    Application = "Portfolio"
+  }
+}
+
+# Environments (staging and production)
+resource "aws_appconfig_environment" "staging" {
+  name           = "staging"
+  description    = "Staging environment for testing features"
+  application_id = aws_appconfig_application.portfolio.id
+
+  tags = {
+    Environment = "Staging"
+  }
+}
+
+resource "aws_appconfig_environment" "production" {
+  name           = "production"
+  description    = "Production environment"
+  application_id = aws_appconfig_application.portfolio.id
+
+  tags = {
+    Environment = "Production"
+  }
+}
+
+# Configuration Profile for Feature Flags
+resource "aws_appconfig_configuration_profile" "feature_flags" {
+  application_id = aws_appconfig_application.portfolio.id
+  name           = "feature-flags"
+  description    = "Feature flags configuration"
+  location_uri   = "hosted"
+  type           = "AWS.AppConfig.FeatureFlags"
+
+  tags = {
+    Type = "FeatureFlags"
+  }
+}
+
+# Deployment Strategy - Immediate (for feature flags)
+resource "aws_appconfig_deployment_strategy" "immediate" {
+  name                           = "portfolio-immediate"
+  description                    = "Immediate deployment for feature flags"
+  deployment_duration_in_minutes = 0
+  final_bake_time_in_minutes     = 0
+  growth_factor                  = 100
+  growth_type                    = "LINEAR"
+  replicate_to                   = "NONE"
+
+  tags = {
+    Strategy = "Immediate"
+  }
+}
+
+# Initial Feature Flags Configuration - Staging (features enabled)
+resource "aws_appconfig_hosted_configuration_version" "staging_flags" {
+  application_id           = aws_appconfig_application.portfolio.id
+  configuration_profile_id = aws_appconfig_configuration_profile.feature_flags.configuration_profile_id
+  description              = "Staging feature flags"
+  content_type             = "application/json"
+
+  content = jsonencode({
+    version = "1"
+    flags = {
+      showAIShowcase = {
+        name = "Show AI Showcase Section"
+      }
+      showContributions = {
+        name = "Show GitHub/GitLab Contributions"
+      }
+      showResumeDownload = {
+        name = "Show Resume Download Button"
+      }
+      enableJobFitAnalyzer = {
+        name = "Enable Job Fit Analyzer"
+      }
+      enableJobFitUrl = {
+        name = "Enable Job Fit URL Input"
+      }
+    }
+    values = {
+      showAIShowcase = {
+        enabled = true
+      }
+      showContributions = {
+        enabled = true
+      }
+      showResumeDownload = {
+        enabled = true
+      }
+      enableJobFitAnalyzer = {
+        enabled = true
+      }
+      enableJobFitUrl = {
+        enabled = true
+      }
+    }
+  })
+}
+
+# Deploy to Staging
+resource "aws_appconfig_deployment" "staging" {
+  application_id           = aws_appconfig_application.portfolio.id
+  configuration_profile_id = aws_appconfig_configuration_profile.feature_flags.configuration_profile_id
+  configuration_version    = aws_appconfig_hosted_configuration_version.staging_flags.version_number
+  deployment_strategy_id   = aws_appconfig_deployment_strategy.immediate.id
+  environment_id           = aws_appconfig_environment.staging.environment_id
+  description              = "Deploy staging feature flags"
+}
+
+# Production Feature Flags Configuration (more conservative)
+resource "aws_appconfig_hosted_configuration_version" "production_flags" {
+  application_id           = aws_appconfig_application.portfolio.id
+  configuration_profile_id = aws_appconfig_configuration_profile.feature_flags.configuration_profile_id
+  description              = "Production feature flags"
+  content_type             = "application/json"
+
+  content = jsonencode({
+    version = "1"
+    flags = {
+      showAIShowcase = {
+        name = "Show AI Showcase Section"
+      }
+      showContributions = {
+        name = "Show GitHub/GitLab Contributions"
+      }
+      showResumeDownload = {
+        name = "Show Resume Download Button"
+      }
+      enableJobFitAnalyzer = {
+        name = "Enable Job Fit Analyzer"
+      }
+      enableJobFitUrl = {
+        name = "Enable Job Fit URL Input"
+      }
+    }
+    values = {
+      showAIShowcase = {
+        enabled = false  # Disabled in prod until fully tested
+      }
+      showContributions = {
+        enabled = true
+      }
+      showResumeDownload = {
+        enabled = false
+      }
+      enableJobFitAnalyzer = {
+        enabled = true
+      }
+      enableJobFitUrl = {
+        enabled = true
+      }
+    }
+  })
+
+  depends_on = [aws_appconfig_hosted_configuration_version.staging_flags]
+}
+
+# Deploy to Production
+resource "aws_appconfig_deployment" "production" {
+  application_id           = aws_appconfig_application.portfolio.id
+  configuration_profile_id = aws_appconfig_configuration_profile.feature_flags.configuration_profile_id
+  configuration_version    = aws_appconfig_hosted_configuration_version.production_flags.version_number
+  deployment_strategy_id   = aws_appconfig_deployment_strategy.immediate.id
+  environment_id           = aws_appconfig_environment.production.environment_id
+  description              = "Deploy production feature flags"
+
+  depends_on = [aws_appconfig_deployment.staging]
+}
+
+# IAM Policy for Lambda to access AppConfig
+resource "aws_iam_policy" "appconfig_policy" {
+  name        = "portfolio_appconfig_policy"
+  description = "Allow Lambda to read AppConfig feature flags"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "appconfig:GetLatestConfiguration",
+          "appconfig:StartConfigurationSession"
+        ]
+        Resource = [
+          "arn:aws:appconfig:us-east-1:*:application/${aws_appconfig_application.portfolio.id}/environment/*/configuration/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "appconfig_attach" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.appconfig_policy.arn
+}
+
+# Outputs
+output "appconfig_application_id" {
+  value       = aws_appconfig_application.portfolio.id
+  description = "AppConfig Application ID"
+}
+
+output "appconfig_staging_environment_id" {
+  value       = aws_appconfig_environment.staging.environment_id
+  description = "AppConfig Staging Environment ID"
+}
+
+output "appconfig_production_environment_id" {
+  value       = aws_appconfig_environment.production.environment_id
+  description = "AppConfig Production Environment ID"
+}
+
+output "appconfig_profile_id" {
+  value       = aws_appconfig_configuration_profile.feature_flags.configuration_profile_id
+  description = "AppConfig Configuration Profile ID"
+}

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -118,4 +118,20 @@ resource "aws_lambda_function" "sync_contributions" {
   }
 }
 
+resource "aws_lambda_function" "get_feature_flags" {
+  filename         = data.archive_file.backend_package.output_path
+  function_name    = "portfolio-get-feature-flags"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = "handlers/get_feature_flags.handler"
+  source_code_hash = data.archive_file.backend_package.output_base64sha256
+  runtime          = "nodejs18.x"
+  timeout          = 10
+  environment {
+    variables = {
+      APPCONFIG_APP_ID     = aws_appconfig_application.portfolio.id
+      APPCONFIG_PROFILE_ID = aws_appconfig_configuration_profile.feature_flags.configuration_profile_id
+    }
+  }
+}
+
 


### PR DESCRIPTION
- Add AppConfig infrastructure (appconfig.tf) with staging and production environments
- Create get_feature_flags Lambda handler with caching and fallback support
- Add API Gateway route for /feature-flags endpoint
- Create frontend FeatureFlagsProvider with React context
- Update AIShowcase to use showAIShowcase feature flag
- Configure different flag values per environment (AI showcase disabled in prod)