### PR TITLE
fix(terraform): add environment suffix to all resource names

### DIFF
--- a/terraform/api_gateway.tf
+++ b/terraform/api_gateway.tf
@@ -1,5 +1,5 @@
 resource "aws_apigatewayv2_api" "http_api" {
-  name          = "portfolio-api"
+  name          = "portfolio-api-${var.environment}"
   protocol_type = "HTTP"
   cors_configuration {
     allow_origins = ["*"] # Lock down to CloudFront domain later

--- a/terraform/appconfig.tf
+++ b/terraform/appconfig.tf
@@ -47,7 +47,7 @@ resource "aws_appconfig_configuration_profile" "feature_flags" {
 
 # Deployment Strategy - Immediate (for feature flags)
 resource "aws_appconfig_deployment_strategy" "immediate" {
-  name                           = "portfolio-immediate"
+  name                           = "portfolio-immediate-${var.environment}"
   description                    = "Immediate deployment for feature flags"
   deployment_duration_in_minutes = 0
   final_bake_time_in_minutes     = 0

--- a/terraform/events.tf
+++ b/terraform/events.tf
@@ -28,7 +28,7 @@ resource "aws_iam_role_policy_attachment" "scheduler_attach" {
 }
 
 resource "aws_scheduler_schedule" "sync_schedule" {
-  name       = "portfolio-sync-contributions-schedule"
+  name       = "portfolio-sync-contributions-schedule-${var.environment}"
   group_name = "default"
 
   flexible_time_window {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -52,7 +52,7 @@ resource "aws_iam_role_policy_attachment" "bedrock_attach" {
 
 resource "aws_lambda_function" "get_content" {
   filename         = data.archive_file.backend_package.output_path
-  function_name    = "portfolio-get-content"
+  function_name    = "portfolio-get-content-${var.environment}"
   role             = aws_iam_role.lambda_role.arn
   handler          = "handlers/get_content.handler"
   source_code_hash = data.archive_file.backend_package.output_base64sha256
@@ -62,7 +62,7 @@ resource "aws_lambda_function" "get_content" {
 
 resource "aws_lambda_function" "enhance_content" {
   filename         = data.archive_file.backend_package.output_path
-  function_name    = "portfolio-enhance-content"
+  function_name    = "portfolio-enhance-content-${var.environment}"
   role             = aws_iam_role.lambda_role.arn
   handler          = "handlers/enhance_content.handler"
   source_code_hash = data.archive_file.backend_package.output_base64sha256
@@ -73,7 +73,7 @@ resource "aws_lambda_function" "enhance_content" {
 
 resource "aws_lambda_function" "sync_contributions" {
   filename         = data.archive_file.backend_package.output_path
-  function_name    = "portfolio-sync-contributions"
+  function_name    = "portfolio-sync-contributions-${var.environment}"
   role             = aws_iam_role.lambda_role.arn
   handler          = "handlers/sync_contributions.handler"
   source_code_hash = data.archive_file.backend_package.output_base64sha256
@@ -84,7 +84,7 @@ resource "aws_lambda_function" "sync_contributions" {
 
 resource "aws_lambda_function" "get_feature_flags" {
   filename         = data.archive_file.backend_package.output_path
-  function_name    = "portfolio-get-feature-flags"
+  function_name    = "portfolio-get-feature-flags-${var.environment}"
   role             = aws_iam_role.lambda_role.arn
   handler          = "handlers/get_feature_flags.handler"
   source_code_hash = data.archive_file.backend_package.output_base64sha256


### PR DESCRIPTION
## Problem
The prod deploy was failing because Lambda functions (and other resources) had the same names in both stage and prod workspaces:
```
ResourceConflictException: Function already exist: portfolio-get-content
```

## Solution
Added `${var.environment}` suffix to all resources that need to be unique per workspace:

- **Lambda functions:** get_content, enhance_content, sync_contributions, get_feature_flags
- **API Gateway:** portfolio-api
- **EventBridge schedule:** sync-contributions-schedule  
- **AppConfig deployment strategy:** portfolio-immediate

## Note
After merging, you may need to manually delete the conflicting Lambda functions in AWS (the ones without the suffix) since Terraform state for prod workspace doesn't know about them. Or run `terraform import` to bring them into state.

---
*Created by Moltbot 🦞*